### PR TITLE
Updating Courses GraphQL to include proper Department

### DIFF
--- a/data.js
+++ b/data.js
@@ -139,6 +139,7 @@ const coursesSchema = mongoose.Schema(
     ],
     deliveryMode: String,
     s3Department: String,
+    department: String,
     courseCode: String,
     title: String,
     parentCourse: mongoose.Schema({

--- a/scheme.js
+++ b/scheme.js
@@ -201,6 +201,7 @@ let coursesType = new graphql.GraphQLObjectType({
     },
     deliveryMode: { type: graphql.GraphQLString },
     s3Department: { type: graphql.GraphQLString },
+    department: { type: graphql.GraphQLString },
     courseCode: { type: graphql.GraphQLString },
     title: { type: graphql.GraphQLString },
     parentCourse: {


### PR DESCRIPTION
# Description
The data for courses was only returning the s3Department for each course that did not map to our internal department identifiers (i.e. 'cs' vs 'csd'). Added the key 'department' that has the right department ID for our application.