### PR TITLE
added a query for a member's andrewID.

### DIFF
--- a/src/queries/members.js
+++ b/src/queries/members.js
@@ -11,6 +11,7 @@ export default {
   description: 'Directory listing',
   args: {
     scid: { type: GraphQLString },
+    andrew_id: { type: GraphQLString },
     department: { type: GraphQLString },
     starts_with: { type: GraphQLString },
     research_area: { type: GraphQLString },
@@ -19,6 +20,8 @@ export default {
   resolve: function(parent, args) {
     if(args.scid){
       return MembersData.find({'scid': args.scid}).then((data) => data)
+    }else if(args.andrew_id){
+      return MembersData.find({'andrew_id': args.andrew_id}).then((data) => data)
     }else if(args.department) {
       return MembersData.find({'positions': {$elemMatch: {'department': args.department }}})
         .then((data) => data)


### PR DESCRIPTION
This is in anticipation of the mapping that will occur between old site and new site for directory pages. Wes should be able to query GraphQL for the match of andrewID to SCID and redirect to the member page on new site.